### PR TITLE
Add generalized Code of Conduct for FPF repositories

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -44,7 +44,7 @@ Members of the community should not:
 - Follow the letter of this Code of Conduct while disregarding its spirit
 
 Members of the community should not hesitate to contact the Community Moderation
-and Safety Team ("Community Team") if they feel someone has violated this Code of
+and Safety Team ("[Community Team](#community-team-members)") if they feel someone has violated this Code of
 Conduct, or if they have questions or concerns.
 
 ## Behavioral Guidelines
@@ -131,7 +131,7 @@ else's behalf without their consent.
 
 ### How to get help
 
-The Community Team is made up of established members of the community who
+The [Community Team](#community-team-members) is made up of established members of the community who
 assist with resolving conflicts within the community. The members of the
 Community Team are listed below.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -133,8 +133,7 @@ else's behalf without their consent.
 
 The Community Team is made up of established members of the community who
 assist with resolving conflicts within the community. The members of the
-Community Teams for different Freedom of the Press Foundation projects are
-listed below.
+Community Team are listed below.
 
 You can contact the whole Community Team or members individually.
 
@@ -151,27 +150,13 @@ resolution proceedings. They will not be involved with the discussion,
 documentation, communications, or decisions made by the rest of the Community
 Team with regards to the incident.
 
-#### For the SecureDrop Project
+#### Community Team Members
 
-Currently the Community Team for SecureDrop consists of:
-
-- Jen Helsby (`@redshiftzero`) - Principal Research Engineer - [jen@freedom.press](mailto:jen@freedom.press)
-- Mickael E. (`@emkll`) - Lead Engineer - [mickael@freedom.press](mailto:mickael@freedom.press)
-
-#### For Freedom of the Press Foundation web projects
-
-For website repositories not related to SecureDrop, the Community Team consists
-of:
-
-- Harris Lapiroff (`@harrislapiroff`) - Principal Web Developer - harris@freedom.press
-
-#### For all other projects
-
-For all other open source projects managed by Freedom of the Press Foundation,
-you can reach out to:
-
-- Conor Schaefer (`@conorsch`) - Chief Technology Officer - conor@freedom.press
-- Erik Moeller (`@eloquence`) - Principal Project Manager - erik@freedom.press
+- Allie Crevier (`@creviera`) - [creviera@freedom.press](mailto:creviera@freedom.press)
+- Conor Schaefer (`@conorsch`) - [conor@freedom.press](mailto:conor@freedom.press)
+- Harlo Holmes (`@harlo`) - [harlo@freedom.press](mailto:harlo@freedom.press)
+- Harris Lapiroff (`@harrislapiroff`) - [harris@freedom.press](mailto:harris@freedom.press)
+- Keturah Dola-Borg (`@ketudb`) - [keturah@freedom.press](mailto:keturah@freedom.press)
 
 ## What the person reporting a violation can expect
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,220 @@
+# Code of Conduct for Freedom of the Press Foundation Open Source Projects
+
+## Preamble
+
+Like the broader technical and activism communities as a whole, the open source
+community contributing to Freedom of the Press Foundation projects is made up of
+a mixture of staff and volunteers from all over the world, engaged in various
+activities—including operations, software development, mentorship, and building
+connections with great people and organizations.
+
+To work together effectively in a large, diverse and open community, we have a
+few ground rules that we expect everyone to adhere to, be it paid staff and
+board members, volunteers and event attendees; mentors, veterans, novices, or
+those seeking help and guidance.
+
+This isn't an exhaustive list of things that you cannot do. Rather, take it in
+the spirit in which it’s intended: a guide to make it easier to enrich all of
+us and the communities in which we participate.
+
+This code of conduct applies to all spaces and events under the responsibility
+of contributors to any open source project managed by Freedom of the Press
+Foundation. This includes physical offices, GitHub repositories, online chat
+systems, forums, hosted or sponsored events, and any other venues created by the
+contributor community which are used for communication.
+
+In addition, we take violations of this code outside these spaces into account
+when determining a person's ability to participate within them.
+
+## Summary
+
+Contributors to this project should feel safe and welcome. They should enjoy
+participating in discussions and contributing. To these ends, members of the
+community should:
+
+- Be friendly and patient
+- Assume good faith and good intentions
+- Be welcoming, considerate, and respectful
+- Be careful in the words they choose
+- Listen to each other, and communicate openly and honestly
+
+Members of the community should not:
+
+- Intimidate, harass, or insult each other
+- Follow the letter of this Code of Conduct while disregarding its spirit
+
+Members of the community should not hesitate to contact the Community Moderation
+and Safety Team ("Community Team") if they feel someone has violated this Code of
+Conduct, or if they have questions or concerns.
+
+## Behavioral Guidelines
+
+As a member of the community, you are expected to:
+
+- Be friendly and patient. Your work will be used by other people, and you in
+  turn will depend on the work of others. Any decision you take will affect
+  human beings, and you should take those consequences into account when making
+  decisions. Remember that our community is international, and that the people
+  you interact with may be communicating with you in a language that is not
+  their native tongue.
+
+- Assume good faith and good intentions. Disagreements — both social and
+  technical — happen all the time. Our diverse backgrounds give us the ability
+  to see things from many different perspectives, but they can also lead to
+  misunderstandings. It is important that we resolve disagreements
+  constructively, and that we do not jump to conclusions about each other's
+  motives.
+
+- Be welcoming, considerate, and respectful. We strive to be a community that
+  welcomes and supports people of all backgrounds and identities. This includes,
+  but is not limited to, members of any race, ethnicity, culture, national
+  origin, color, immigration status, social and economic class, educational
+  level, sex, sexual orientation, gender identity and expression, age, size,
+  family status, political belief, religion and mental and physical ability.
+
+- Be careful in the words you choose. Exclusionary behavior is absolutely
+  unacceptable. This includes, but is not limited to:
+
+  - Discriminatory (e.g., racist or sexist) jokes and language
+  - Inappropriate names for user accounts, servers, files, repositories, etc.
+  - Posting sexually explicit or violent material
+  - Personal insults
+  - Misgendering or deadnaming
+  - Unwelcome sexual attention
+  - Advocating for, or encouraging, any of the above behavior
+
+- Listen and communicate openly and honestly. Yield the floor to
+  others, and help to make sure that everyone gets heard. In other words, try to
+  be your best self. In doing so, you contribute the health and longevity of
+  this community.
+
+As a member of the community, you are expected to never engage in the
+following behaviors:
+
+- Intimidation, harassments, or insults.  This includes but is not limited to:
+  - Physical intimidation or threats against someone's physical safety
+  - Obscene or intimidating gestures
+  - Stalking
+  - Demeaning another person
+  - Unwelcome following
+  - Enlisting the help of others, whether in person or online, in order to
+    target an individual
+  - Taking photographs, video, or audio recordings or recordings without consent
+  - Shouting
+  - Sustained disruption of talks and events
+  - Disruption of meetings
+  - Inappropriate physical contact
+  - Unwelcome sexual attention
+  - Posting (or threatening to post) other people's personally identifying
+    information ("doxing")
+  - Violation of people's stated personal boundaries
+
+- Following the letter of this Code of Conduct while disregarding its spirit.
+  When judging whether certain behavior represents a violation of this code, we
+  will consider a violation in spirit (e.g., clearly behaving in a damaging or
+  obnoxious manner in a way not explicitly specified) to be no different from
+  any other violation of this code. That includes trolling and other forms of
+  consistently disruptive behavior.
+
+## Enforcement
+
+We do not tolerate unacceptable behavior from any community member, and there
+are no exceptions for those in positions of power such as maintainers,
+sponsors, funders, or other individuals with decision making authority.
+Further, people in positions of power can wield it to exacerbate the effects of
+harassment and to diminish the repercussions. For these reasons, those who are
+informal or formal leaders are held to a higher standard.
+
+Anyone asked by another community member to stop unacceptable behavior is
+expected to comply immediately. However, you should not step in on someone
+else's behalf without their consent.
+
+### How to get help
+
+The Community Team is made up of established members of the community who
+assist with resolving conflicts within the community. The members of the
+Community Teams for different Freedom of the Press Foundation projects are
+listed below.
+
+You can contact the whole Community Team or members individually.
+
+You should contact the Community Team if you have questions or concerns about
+the Code of Conduct (including improvements) or if you feel that you have
+witnessed a Code of Conduct violation. In the event of a violation either
+directed at yourself or someone else, please contact the Community Team as
+soon as possible through whatever analog or digital medium you are most
+comfortable with.
+
+Should your report be about any member of the Community Team or if there is a
+conflict of interest, that member will recuse themselves from the conflict
+resolution proceedings. They will not be involved with the discussion,
+documentation, communications, or decisions made by the rest of the Community
+Team with regards to the incident.
+
+#### For the SecureDrop Project
+
+Currently the Community Team for SecureDrop consists of:
+
+- Jen Helsby (`@redshiftzero`) - Principal Research Engineer - [jen@freedom.press](mailto:jen@freedom.press)
+- Mickael E. (`@emkll`) - Lead Engineer - [mickael@freedom.press](mailto:mickael@freedom.press)
+
+#### For Freedom of the Press Foundation web projects
+
+For website repositories not related to SecureDrop, the Community Team consists
+of:
+
+- Harris Lapiroff (`@harrislapiroff`) - Principal Web Developer - harris@freedom.press
+
+#### For all other projects
+
+For all other open source projects managed by Freedom of the Press Foundation,
+you can reach out to:
+
+- Conor Schaefer (`@conorsch`) - Chief Technology Officer - conor@freedom.press
+- Erik Moeller (`@eloquence`) - Principal Project Manager - erik@freedom.press
+
+## What the person reporting a violation can expect
+
+The Community Team will respond to reports as quickly as possible. When
+responding to a report, the Community Team will prioritize the safety of the
+person(s) who have been harmed or are at risk of harm and the reporter(s). No
+actions will be taken without the consent of the person who has been harmed or
+is at risk of harm except in cases where danger or harm are imminent.
+
+All reports to the Community Team, no matter how minor or severe, will be
+taken seriously and looked into.
+
+## How the Community Team responds to incidents
+
+The Community Team does not have a fixed set of responses to some enumerated
+set of incidents that may occur. The Community Team operates on a
+case-by-case basis taking into account past behavior; the relationship between
+the person(s) who were harmed and the person(s) causing the harm; the responses
+of the person(s) who caused harm; and the perceived threat of future harm.
+
+Actions the Community Team may take to mitigate harm include, but are not
+limited to:
+
+- A simple warning
+- Informal mediation
+- A temporary ban from email lists, chat channels, repositories, or other online
+  communication mediums
+- A temporary ban from events or community spaces
+- Permanent expulsion from the community
+
+Once the Community Team has reached a decision on how to mitigate the harm or
+risk of harm, the person(s) on the receiving end of the mitigation(s) may appeal
+the decision by writing or otherwise communicating with the Community Team.
+
+## License and Attribution
+
+Parts of this code of conduct are derived from or inspired by:
+
+- The Citizen Code of Conduct
+- The Django Code of Conduct
+- The Tor Project Code of Conduct
+- The OpenStack Foundation Community Code of Conduct
+- The Freedom of the Press Foundation Code of Conduct
+
+This Code of Conduct is shared under a Creative Commons CC-BY-SA 4.0 International
+license.


### PR DESCRIPTION
Per https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file, this provides a default code of conduct for all repos under the `freedomofpress` umbrella.

If this looks good and we can verify post-merge that it works as expected in repositories *without* a Code of Conduct, we could potentially remove the project-specific copies, reducing the maintenance workload.

In order to make the Code of Conduct generalizable, I had to update some language that was project-specific, and enumerate the points of contact for different projects (SecureDrop vs. web vs. everything else).

For now I've volunteered Conor and myself for the "everything else" category, but happy to update that as y'all see fit.